### PR TITLE
Fix broken git cheatsheet URL

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -5,7 +5,7 @@ permalink: /reference/
 
 ## Git Cheatsheets for Quick Reference
 
-*   A great [printable git cheatsheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf) is available in PDF from the
+*   A great [printable git cheatsheet](https://github.github.com/training-kit/downloads/github-git-cheat-sheet.pdf) is available in PDF from the
 [GitHub training website](https://services.github.com/resources/).
 *   An [interactive one-page visualisation](http://ndpsoftware.com/git-cheatsheet.html)
     about the relationships between workspace, staging area, local repository, upstream repository, and the commands associated with each (with explanations).


### PR DESCRIPTION
I noticed that the cheatsheet URL doesn't lead to anything valid any more. At least not for me.

This new URL seems to be the best I could find on github's site.
